### PR TITLE
fix: make `opts` optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ module.exports = class DazaarPayment {
   }
 }
 
-function findProvider (seller, payment, opts) {
+function findProvider (seller, payment, opts = {}) {
   for (const [label, P] of providers) {
     if (P.supports(payment) && (!payment.label || label === payment.label)) {
       return new P(seller, payment, opts[label])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dazaar/payment",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Dazaar payment manager",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
fixes

```
/Users/robert/bitfinex/dazaar-payment/index.js:106
      return new P(seller, payment, opts[label])
                                        ^

TypeError: Cannot read property 'eos' of undefined
    at findProvider (/Users/robert/bitfinex/dazaar-payment/index.js:106:41)
    at new DazaarPayment (/Users/robert/bitfinex/dazaar-payment/index.js:22:19)
    at /Users/robert/bitfinex/dazaar/examples/eos-testnet.js:32:13
    at apply (/Users/robert/bitfinex/dazaar/node_modules/thunky/index.js:44:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

in the dazaar examples:
https://github.com/bitfinexcom/dazaar/blob/master/examples/eos-testnet.js